### PR TITLE
Added getServiceInstanceInfo API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
 		<connection>scm:git:git@github.com:IBM-Bluemix/gp-java-client.git</connection>
 		<developerConnection>scm:git:git@github.com:IBM-Bluemix/gp-java-client.git</developerConnection>
 		<url>git@github.com:IBM-Bluemix/gp-java-client.git</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<distributionManagement>
 		<snapshotRepository>

--- a/src/main/java/com/ibm/g11n/pipeline/client/BundleData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/BundleData.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <code>BundleData</code> provides a read access to translation bundle's
+ * <code>BundleData</code> provides read access to the translation bundle's
  * properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/BundleData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/BundleData.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <code>BundleData</code> provides read access to translation bundle's
+ * <code>BundleData</code> provides a read access to translation bundle's
  * properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/MTServiceBindingData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/MTServiceBindingData.java
@@ -20,7 +20,7 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * <code>MTServiceBindingData</code> provides a read access to machine translation service
+ * <code>MTServiceBindingData</code> provides read access to the machine translation service
  * binding data properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/MTServiceBindingData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/MTServiceBindingData.java
@@ -20,7 +20,7 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * <code>MTServiceBindingData</code> provides read access to machine translation service
+ * <code>MTServiceBindingData</code> provides a read access to machine translation service
  * binding data properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/NewTranslationConfigData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/NewTranslationConfigData.java
@@ -1,0 +1,107 @@
+/*  
+ * Copyright IBM Corp. 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.g11n.pipeline.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <code>NewTranslationConfigData</code> is used for specifying translation
+ * configuration for each source/target language pair.
+ * 
+ * @author Yoshito Umaoka
+ */
+public class NewTranslationConfigData {
+    private NewMTServiceData mtService;
+
+    /**
+     * Constructor.
+     */
+    public NewTranslationConfigData() {
+    }
+
+    /**
+     * Sets the machine translation service configuration.
+     * 
+     * @param mtService The machine translation service configuration.
+     */
+    public void setMTServiceData(NewMTServiceData mtService) {
+        this.mtService = mtService;
+    }
+
+    /**
+     * Returns the machine translation service configuration.
+     * 
+     * @return The machine translation service configuration.
+     */
+    public NewMTServiceData getMTServiceData() {
+        return mtService;
+    }
+
+    /**
+     * <code>NewMTServiceData</code> is used for specifying machine translation
+     * service configuration.
+     * 
+     * @author Yoshito Umaoka
+     */
+    public static class NewMTServiceData {
+        private String serviceInstanceId;
+        private Map<String, Object> params;
+
+        /**
+         * Constructor.
+         * 
+         * @param serviceInstanceId The ID of machine translation service instance.
+         */
+        public NewMTServiceData(String serviceInstanceId) {
+            this.serviceInstanceId = serviceInstanceId;
+        }
+
+        /**
+         * Returns the ID of machine translation service instance.
+         * 
+         * @return The ID of machine translation service instance.
+         */
+        public String getServiceInstanceId() {
+            return serviceInstanceId;
+        }
+
+        /**
+         * Sets optional parameters (key/value pairs) that will be passed to
+         * the machine translation service instance.
+         * 
+         * @param params    The optional parameters (key/value pairs).
+         */
+        public void setParams(Map<String, Object> params) {
+            this.params = new HashMap<>(params);
+        }
+
+        /**
+         * Returns a map containing optional parameters (key/value pairs) that will
+         * be passed to the translation service instance.
+         * 
+         * @return A map containing optional parameters (key/value pairs) that will
+         * be passed to the translation service instance.
+         */
+        public Map<String, Object> getParams() {
+            if (params == null) {
+                return null;
+            }
+            return Collections.unmodifiableMap(params);
+        }
+    }
+}

--- a/src/main/java/com/ibm/g11n/pipeline/client/ResourceEntryData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/ResourceEntryData.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * <code>ResourceEntryData</code> provides a read access to resource entry's
+ * <code>ResourceEntryData</code> provides read access to the resource entry's
  * properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/ResourceEntryData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/ResourceEntryData.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * <code>ResourceEntryData</code> provides read access to resource entry's
+ * <code>ResourceEntryData</code> provides a read access to resource entry's
  * properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/ServiceClient.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/ServiceClient.java
@@ -133,6 +133,18 @@ public abstract class ServiceClient {
     public abstract ServiceInfo getServiceInfo() throws ServiceException;
 
     //
+    // {serviceInstanceId}/v2/instance APIs
+    //
+
+    /**
+     * Returns the service instance information.
+     * 
+     * @return The service instance information.
+     * @throws ServiceException when the operation failed.
+     */
+    public abstract ServiceInstanceInfo getServiceInstanceInfo() throws ServiceException;
+
+    //
     // {serviceInstanceId}/v2/bundles APIs
     //
 
@@ -559,7 +571,7 @@ public abstract class ServiceClient {
      * languages.
      * @throws ServiceException when the operation failed.
      */
-    public abstract Map<String, Map<String, TranslationConfigData>> getAllTranslationConfigs()
+    public abstract Map<String, Map<String, NewTranslationConfigData>> getAllTranslationConfigs()
             throws ServiceException;
 
     /**
@@ -580,18 +592,18 @@ public abstract class ServiceClient {
             throws ServiceException;
 
     /**
-     * Puts the <code>TranslationConfigData</code> for the specified source/target language pairs.
+     * Puts the <code>NewTranslationConfigData</code> for the specified source/target language pairs.
      * <p>
      * If there is an existing <code>TranslationConfigData</code> for the language pair,
      * this method will overwrite the existing data with new one.
      * 
      * @param sourceLanguage    The translation source language.
      * @param targetLanguage    The translation target language.
-     * @param configData        The translation configuration data.
+     * @param configData        The new translation configuration data.
      * @throws ServiceException when the operation failed.
      */
     public abstract void putTranslationConfig(String sourceLanguage, String targetLanguage,
-            TranslationConfigData configData) throws ServiceException;
+            NewTranslationConfigData configData) throws ServiceException;
 
     /**
      * Returns the <code>TranslationConfigData</code> for the specified source/target language pairs.

--- a/src/main/java/com/ibm/g11n/pipeline/client/ServiceInstanceInfo.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/ServiceInstanceInfo.java
@@ -18,7 +18,7 @@ package com.ibm.g11n.pipeline.client;
 import java.util.Date;
 
 /**
- * <code>ServiceInstanceInfo</code> provides a read access to a service instance's
+ * <code>ServiceInstanceInfo</code> provides read access to the service instance's
  * properties.
  * 
  * @author Yoshito Umaoka
@@ -33,7 +33,7 @@ public abstract class ServiceInstanceInfo {
     private final boolean disabled;
 
     /**
-     * <code>UsageData</code> provides a read access to a service instance's
+     * <code>UsageData</code> provides read access to the service instance's
      * usage information.
      * 
      * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/ServiceInstanceInfo.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/ServiceInstanceInfo.java
@@ -1,0 +1,202 @@
+/*  
+ * Copyright IBM Corp. 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.g11n.pipeline.client;
+
+import java.util.Date;
+
+/**
+ * <code>ServiceInstanceInfo</code> provides a read access to a service instance's
+ * properties.
+ * 
+ * @author Yoshito Umaoka
+ */
+public abstract class ServiceInstanceInfo {
+    private final String region;
+    private final String orgId;
+    private final String spaceId;
+    private final String serviceId;
+    private final String planId;
+    private final String cfServiceInstanceId;
+    private final boolean disabled;
+
+    /**
+     * <code>UsageData</code> provides a read access to a service instance's
+     * usage information.
+     * 
+     * @author Yoshito Umaoka
+     */
+    public static class UsageData {
+        private final long size;
+
+        /**
+         * Protected constructor for a subclass extending <code>UsageData</code>.
+         * 
+         * @param size The resource data size.
+         */
+        protected UsageData(long size) {
+            this.size = size;
+        }
+
+        /**
+         * Returns the size of resource data used by the Globalization
+         * Pipeline instance in bytes.
+         * 
+         * @return The size of resource data used by the Globalization
+         * Pipeline instance in bytes.
+         */
+        public long getSize() {
+            return size;
+        }
+    }
+    private final UsageData usageData;
+
+    private final String updatedBy;
+    private final Date updatedAt;
+
+    /**
+     * Protected constructor for a subclass extending <code>ServiceInstanceData</code>.
+     * 
+     * @param region    The service instance owner's region.
+     * @param orgId     The service instance owner's organization ID.
+     * @param spaceId   The ID of the space where the service instance was created.
+     * @param serviceId The service ID of Globalization Pipeline
+     * @param planId    The Globalization Pipeline's plan ID used by this service instance.
+     * @param cfServiceInstanceId   The service instance ID assigned by Bluemix Cloud Foundry.
+     * @param disabled  Whether if this service instance is disabled.
+     * @param usageData The usage data.
+     * @param updatedBy The last user updated the service instance data.
+     * @param updatedAt The last date when the service instance data was updated (except usage data).
+     */
+    protected ServiceInstanceInfo(String region, String orgId, String spaceId,
+            String serviceId, String planId, String cfServiceInstanceId, boolean disabled,
+            UsageData usageData, String updatedBy, Date updatedAt) {
+        this.region = region;
+        this.orgId = orgId;
+        this.spaceId = spaceId;
+        this.serviceId = serviceId;
+        this.planId = planId;
+        this.cfServiceInstanceId = cfServiceInstanceId;
+        this.disabled = disabled;
+
+        this.usageData = usageData;
+
+        this.updatedBy = updatedBy;
+        this.updatedAt = updatedAt;
+    }
+
+    /**
+     * Returns the Bluemix region where the owner of this Globalization
+     * Pipeline service is in.
+     * 
+     * @return The Bluemix  region where the owner of this Globalization
+     * Pipeline service is in.
+     */
+    public final String getRegion() {
+        return region;
+    }
+
+    /**
+     * Returns the ID of Blumix organization owning the Globalization Pipeline
+     * service instance.
+     * 
+     * @return The ID of Blumix organization owning the Globalization Pipeline
+     * service instance.
+     */
+    public final String getOrgId() {
+        return orgId;
+    }
+
+    /**
+     * Returns the ID of user's space where the Globalization Pipeline service
+     * instance was created.
+     * 
+     * @return The ID of user's space where the Globalization Pipeline service
+     * instance was created.
+     */
+    public final String getSpaceId() {
+        return spaceId;
+    }
+
+    /**
+     * Returns the service ID.
+     * <p>Note: The service ID is assigned for Globalization Pipeline service.
+     * So this API returns the same ID always.
+     * 
+     * @return The service ID.
+     */
+    public final String getServiceId() {
+        return serviceId;
+    }
+
+    /**
+     * Returns the plan ID used by the service instance.
+     * 
+     * @return The plan ID used by the service instance.
+     */
+    public final String getPlanId() {
+        return planId;
+    }
+
+    /**
+     * Returns the service instance ID assigned by Bluemix CF.
+     * <p>Note: This ID is different from service instance ID
+     * assigned by the Globalization Pipeline service.
+     * 
+     * @return The service instance ID assigned by Bluemix CF.
+     */
+    public final String getCfServiceIntanceId() {
+        return cfServiceInstanceId;
+    }
+
+
+    /**
+     * Returns if this service instance is disabled.
+     * 
+     * @return <code>true</code> if this service instance is disabled.
+     */
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    /**
+     * Returns the current usage data of this service instance.
+     * 
+     * @return The current usage data of this service instance.
+     */
+    public final UsageData getUsageData() {
+        return usageData;
+    }
+
+    /**
+     * Returns the last user updated this service instance data.
+     * 
+     * @return The last user updated this service instance data.
+     */
+    public final String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    /**
+     * Returns the last date when this service instance data was updated.
+     * <p>Note: The usage data is not counted as last update.
+     * 
+     * @return The last date when this service instance data was updated.
+     */
+    public final Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+}

--- a/src/main/java/com/ibm/g11n/pipeline/client/TranslationConfigData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/TranslationConfigData.java
@@ -15,62 +15,106 @@
  */
 package com.ibm.g11n.pipeline.client;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
- * <code>TranslationConfigData</code> represents translation configuration
- * for each translation source/target language pair.
+ * <code>TranslationConfigData</code> provides a read only access to translation
+ * configuration for each source/target language pair.
  * 
  * @author Yoshito Umaoka
  */
-public class TranslationConfigData {
-    private MTServiceData mtService;
+public abstract class TranslationConfigData {
+    private final String updatedBy;
+    private final Date updatedAt;
 
-    protected TranslationConfigData() {
+    /**
+     * Protected constructor for a subclass extending <code>TranslationConfigData</code>.
+     * 
+     * @param updatedBy The last user updated this translation configuration.
+     * @param updatedAt The last date when this translation configuration was updated.
+     */
+    protected TranslationConfigData(String updatedBy, Date updatedAt) {
+        this.updatedBy = updatedBy;
+        this.updatedAt = updatedAt;
     }
 
-    public void setMTServiceData(MTServiceData mtService) {
-        this.mtService = mtService;
+    public abstract MTServiceData getMTServiceData();
+
+    /**
+     * Returns the last user updated this translation configuration.
+     * 
+     * @return The last user updated this translation configuration.
+     */
+    public final String getUpdatedBy() {
+        return updatedBy;
     }
 
-    public MTServiceData getMTServiceData() {
-        return mtService;
+    /**
+     * Returns the last date when this translation configuration was updated.
+     * 
+     * @return The last date when this translation configuration was updated.
+     */
+    public final Date getUpdatedAt() {
+        return updatedAt;
     }
 
-    public String getUpdatedBy() {
-        return null;
-    }
+    public static abstract class MTServiceData {
+        private final String serviceInstanceId;
+        protected final String updatedBy;
+        protected final Date updatedAt;
 
-    public Date getUpdatedAt() {
-        return null;
-    }
-
-    public static class MTServiceData {
-        private String serviceInstanceId;
-        protected Map<String, Object> params;
-        protected String updatedBy; // only set by subclass
-        protected Date updatedAt;   // only set by subclass
-
-        public MTServiceData(String serviceInstanceId) {
+        /**
+         * Protected constructor for a subclass extending <code>MTServiceData</code>.
+         * 
+         * @param serviceInstanceId The ID of machine translation service instance.
+         * @param updatedBy The last user updated this machine translation service
+         *                  configuration.
+         * @param updatedAt The last date when this machine translation service
+         *                  configuration was updated.
+         */
+        public MTServiceData(String serviceInstanceId, String updatedBy, Date updatedAt) {
             this.serviceInstanceId = serviceInstanceId;
+            this.updatedBy = updatedBy;
+            this.updatedAt = updatedAt;
         }
 
-        public String getServiceInstanceId() {
+        /**
+         * Returns the ID of machine translation service instance.
+         * 
+         * @return The ID of machine translation service instance.
+         */
+        public final String getServiceInstanceId() {
             return serviceInstanceId;
         }
 
-        public void setParams(Map<String, Object> params) {
-            this.params = new HashMap<>(params);
+        /**
+         * Returns a map containing optional parameters (key/value pairs) that will
+         * be passed to the translation service instance.
+         * 
+         * @return A map containing optional parameters (key/value pairs) that will
+         * be passed to the translation service instance.
+         */
+        public abstract Map<String, Object> getParams();
+
+        /**
+         * Returns the last user updated this machine translation service configuration.
+         * 
+         * @return The last user updated this machine translation service configuration.
+         */
+        public final String getUpdatedBy() {
+            return updatedBy;
         }
 
-        public Map<String, Object> getParams() {
-            if (params == null) {
-                return null;
-            }
-            return Collections.unmodifiableMap(params);
+        /**
+         * Returns the last date when this machine translation service configuration
+         * was updated.
+         * 
+         * @return The last date when this machine translation service configuration was
+         * updated.
+         */
+        public final Date getUpdatedAt() {
+            return updatedAt;
         }
     }
 }

--- a/src/main/java/com/ibm/g11n/pipeline/client/UserData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/UserData.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <code>UserData</code> provides a read access to service user's
+ * <code>UserData</code> provides read access to the service user's
  * properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/UserData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/UserData.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <code>UserData</code> provides read access to service user's
+ * <code>UserData</code> provides a read access to service user's
  * properties.
  * 
  * @author Yoshito Umaoka

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/MTServiceBindingDataImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/MTServiceBindingDataImpl.java
@@ -24,7 +24,7 @@ import com.ibm.g11n.pipeline.client.MTServiceBindingData;
  * 
  * @author Yoshito Umaoka
  */
-public class MTServiceBindingDataImpl extends MTServiceBindingData {
+class MTServiceBindingDataImpl extends MTServiceBindingData {
 
     private final RestMTServiceBinding mtServiceBinding;
 

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/ResourceEntryDataImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/ResourceEntryDataImpl.java
@@ -26,7 +26,7 @@ import com.ibm.g11n.pipeline.client.TranslationStatus;
  * 
  * @author Yoshito Umaoka
  */
-public class ResourceEntryDataImpl extends ResourceEntryData {
+class ResourceEntryDataImpl extends ResourceEntryData {
 
     private final RestResourceEntry resourceEntry;
 

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceInstanceInfoImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceInstanceInfoImpl.java
@@ -1,0 +1,135 @@
+/*  
+ * Copyright IBM Corp. 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.g11n.pipeline.client.impl;
+
+import java.util.Date;
+
+import com.ibm.g11n.pipeline.client.ServiceInstanceInfo;
+
+/**
+ * {@link ServiceInstanceInfo} implementation class.
+ * 
+ * @author Yoshito Umaoka
+ */
+class ServiceInstanceInfoImpl extends ServiceInstanceInfo {
+    static class UsageDataImpl extends UsageData {
+        protected UsageDataImpl(RestUsageData restUsageData) {
+            super(restUsageData.getSize());
+        }
+    }
+
+    ServiceInstanceInfoImpl(RestServiceInstanceInfo restServiceInstanceInfo) {
+        super(
+            restServiceInstanceInfo.getRegion(),
+            restServiceInstanceInfo.getOrgId(),
+            restServiceInstanceInfo.getSpaceId(),
+            restServiceInstanceInfo.getServiceId(),
+            restServiceInstanceInfo.getPlanId(),
+            restServiceInstanceInfo.getCfServiceInstanceId(),
+            restServiceInstanceInfo.isDisabled(),
+            (restServiceInstanceInfo.getUsageData() != null ?
+                    new UsageDataImpl(restServiceInstanceInfo.getUsageData()) : null),
+            restServiceInstanceInfo.getUpdatedBy(),
+            restServiceInstanceInfo.getUpdatedAt());
+    }
+
+    /**
+     * Data object used for deserializing external service instance info in JSON.
+     * 
+     * @author Yoshito Umaoka
+     */
+    static class RestServiceInstanceInfo {
+        private String region;
+        private String cfServiceInstanceId;
+        private String serviceId;
+        private String orgId;
+        private String spaceId;
+        private String planId;
+        private Boolean disabled;
+        private RestUsageData usage;
+        private String updatedBy;
+        private Date updatedAt;
+
+        /**
+         * No-args constructor used by JSON unmarshaller
+         */
+        RestServiceInstanceInfo() {
+        }
+
+        public String getRegion() {
+            return region;
+        }
+
+        public String getCfServiceInstanceId() {
+            return cfServiceInstanceId;
+        }
+
+        public String getServiceId() {
+            return serviceId;
+        }
+
+        public String getOrgId() {
+            return orgId;
+        }
+
+        public String getSpaceId() {
+            return spaceId;
+        }
+
+        public String getPlanId() {
+            return planId;
+        }
+
+        public boolean isDisabled() {
+            if (disabled != null) {
+                return disabled.booleanValue();
+            }
+            return false;
+        }
+
+        public RestUsageData getUsageData() {
+            return usage;
+        }
+
+        public String getUpdatedBy() {
+            return updatedBy;
+        }
+
+        public Date getUpdatedAt() {
+            return updatedAt;
+        }
+    }
+
+    /**
+     * Data object used for deserializing external service instance's usage
+     * data in JSON.
+     * 
+     * @author Yoshito Umaoka
+     */
+    static class RestUsageData {
+        private long size = -1;
+
+        /**
+         * No-args constructor used by JSON unmarshaller
+         */
+        RestUsageData() {
+        }
+
+        long getSize() {
+            return size;
+        }
+    }
+}

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/TranslationConfigDataImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/TranslationConfigDataImpl.java
@@ -15,41 +15,46 @@
  */
 package com.ibm.g11n.pipeline.client.impl;
 
-import java.util.Date;
+import java.util.Collections;
 import java.util.Map;
 
 import com.ibm.g11n.pipeline.client.TranslationConfigData;
 
 /**
- * TranslationConfigData implementation class
+ * TranslationConfigData implementation class.
  * 
  * @author Yoshito Umaoka
  */
-public class TranslationConfigDataImpl extends TranslationConfigData {
-    RestTranslationConfigData restTransConfig;
+class TranslationConfigDataImpl extends TranslationConfigData {
+
+    static class MTServiceDataImpl extends MTServiceData {
+        private final Map<String, Object> params;
+ 
+        MTServiceDataImpl(RestMTServiceData restMTService) {
+            super(restMTService.getServiceInstanceId(),
+                    restMTService.getUpdatedBy(), restMTService.getUpdatedAt());
+            this.params = restMTService.getParams();
+        }
+
+        @Override
+        public Map<String, Object> getParams() {
+            if (params == null) {
+                return null;
+            }
+            return Collections.unmodifiableMap(params);
+        }
+    }
+
+    MTServiceDataImpl mtService;
 
     TranslationConfigDataImpl(RestTranslationConfigData restTransConfig) {
-        this.restTransConfig = restTransConfig;
-        if (restTransConfig.mtService != null) {
-            setMTServiceData(new MTServiceDataImpl(restTransConfig.mtService));
-        }
+        super(restTransConfig.getUpdatedBy(), restTransConfig.getUpdatedAt());
+        this.mtService = new MTServiceDataImpl(restTransConfig.getMTService());
     }
 
-    public static class MTServiceDataImpl extends MTServiceData {
-        MTServiceDataImpl(RestMTServiceData restMTService) {
-            super(restMTService.getServiceInstanceId());
-            this.params = restMTService.getParams();
-            this.updatedBy = restMTService.getUpdatedBy();
-            this.updatedAt = restMTService.getUpdatedAt();
-        }
-    }
-
-    public String getUpdatedBy() {
-        return restTransConfig.getUpdatedBy();
-    }
-
-    public Date getUpdatedAt() {
-        return restTransConfig.getUpdatedAt();
+    @Override
+    public MTServiceData getMTServiceData() {
+        return mtService;
     }
 
     /**
@@ -58,16 +63,16 @@ public class TranslationConfigDataImpl extends TranslationConfigData {
      * @author Yoshito Umaoka
      */
     static class RestTranslationConfigData extends RestObject {
-        private RestMTServiceData mtService;
+        private RestMTServiceData restMTService;
 
         /**
          * No-args constructor used by JSON unmarshaller
          */
-        private RestTranslationConfigData() {
+        RestTranslationConfigData() {
         }
 
         public RestMTServiceData getMTService() {
-            return mtService;
+            return restMTService;
         }
     }
 
@@ -84,7 +89,7 @@ public class TranslationConfigDataImpl extends TranslationConfigData {
         /**
          * No-args constructor used by JSON unmarshaller
          */
-        private RestMTServiceData() {
+        RestMTServiceData() {
         }
 
         public String getServiceInstanceId() {

--- a/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientConfigTest.java
+++ b/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientConfigTest.java
@@ -35,6 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.ibm.g11n.pipeline.client.NewTranslationConfigData.NewMTServiceData;
 import com.ibm.g11n.pipeline.client.TranslationConfigData.MTServiceData;
 
 /**
@@ -74,9 +75,9 @@ public class ServiceClientConfigTest extends AbstractServiceClientTest {
 
                 // external service binding is available
                 if (WATSON_GUID != null || CAPITA_GUID != null) {
-                    Map<String, Map<String, TranslationConfigData>> allConfigs =
+                    Map<String, Map<String, NewTranslationConfigData>> allConfigs =
                             client.getAllTranslationConfigs();
-                    Map<String, TranslationConfigData> langConfig = allConfigs.get(TEST_CONFIG_SRC);
+                    Map<String, NewTranslationConfigData> langConfig = allConfigs.get(TEST_CONFIG_SRC);
                     if (langConfig == null) {
                         TEST_CONFIG = true;
                     } else {
@@ -98,9 +99,9 @@ public class ServiceClientConfigTest extends AbstractServiceClientTest {
     @After
     public void cleanupTestTransConfig() throws ServiceException {
         if (TEST_CONFIG) {
-            Map<String, Map<String, TranslationConfigData>> allConfigs =
+            Map<String, Map<String, NewTranslationConfigData>> allConfigs =
                     client.getAllTranslationConfigs();
-            Map<String, TranslationConfigData> langConfig = allConfigs.get(TEST_CONFIG_SRC);
+            Map<String, NewTranslationConfigData> langConfig = allConfigs.get(TEST_CONFIG_SRC);
             if (langConfig != null && langConfig.containsKey(TEST_CONFIG_TGT)) {
                 client.deleteTranslationConfig(TEST_CONFIG_SRC, TEST_CONFIG_TGT);
             }
@@ -198,11 +199,11 @@ public class ServiceClientConfigTest extends AbstractServiceClientTest {
     @Test
     public void getAllTranslationConfig_Configs_TestLangPairShouldNotExist() throws ServiceException {
         assumeTrue(TEST_CONFIG);
-        Map<String, Map<String, TranslationConfigData>> allConfigs = client.getAllTranslationConfigs();
+        Map<String, Map<String, NewTranslationConfigData>> allConfigs = client.getAllTranslationConfigs();
         assertNotNull("getAllTranslationConfigs should not return null", allConfigs);
 
         // When TEST_CONFIG is true, config for en-fr should not exist
-        Map<String, TranslationConfigData> testSrcConfigs = allConfigs.get(TEST_CONFIG_SRC);
+        Map<String, NewTranslationConfigData> testSrcConfigs = allConfigs.get(TEST_CONFIG_SRC);
         if (TEST_CONFIG_SRC != null) {
             assertNull("language pair for testing should not exist",
                     testSrcConfigs.get(TEST_CONFIG_TGT));
@@ -327,11 +328,11 @@ public class ServiceClientConfigTest extends AbstractServiceClientTest {
 
     private static void putTestTransConfig(String srcLang, String tgtLang, 
             String mtServiceInstanceId, Map<String, Object> params) throws ServiceException {
-        MTServiceData mtService = new MTServiceData(mtServiceInstanceId);
+        NewMTServiceData mtService = new NewMTServiceData(mtServiceInstanceId);
         if (params != null) {
             mtService.setParams(params);
         }
-        TranslationConfigData transConfig = new TranslationConfigData();
+        NewTranslationConfigData transConfig = new NewTranslationConfigData();
         transConfig.setMTServiceData(mtService);
         client.putTranslationConfig(srcLang, tgtLang, transConfig);
     }
@@ -349,6 +350,6 @@ public class ServiceClientConfigTest extends AbstractServiceClientTest {
         assertNotNull("MT service data should not be null", mtServiceData);
         assertEquals("MT service instance ID should match", expInstanceId,
                 mtServiceData.getServiceInstanceId());
-        assertEquals("MT service params should match", expParams, mtServiceData.params);
+        assertEquals("MT service params should match", expParams, mtServiceData.getParams());
     }
 }

--- a/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientInstanceTest.java
+++ b/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientInstanceTest.java
@@ -1,0 +1,43 @@
+/*  
+ * Copyright IBM Corp. 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.g11n.pipeline.client;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.g11n.pipeline.client.ServiceInstanceInfo.UsageData;
+
+/**
+ * Test cases for service instance APIs in ServiceClient.
+ * 
+ * @author Yoshito Umaoka
+ */
+public class ServiceClientInstanceTest extends AbstractServiceClientTest {
+
+    //
+    // getServiceInstanceInfo
+    //
+
+    @Test
+    public void getServiceInstanceInfo_UsageSize_ShouldBePositive() throws ServiceException {
+        ServiceInstanceInfo instanceInfo = client.getServiceInstanceInfo();
+        UsageData usage = instanceInfo.getUsageData();
+        assertNotNull("Usage data should be non-null", usage);
+        assertTrue("Usage size should be positive", usage.getSize() > 0);
+    }
+}


### PR DESCRIPTION
Also, split TranslationConfigData into two, one for creating a new configuration, and another for read-only access including some system generated fields (updatedBy, updatedAt).