### PR TITLE
Use guava BaseEncoding instead of problematic DatatypeConverter

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>gaas-java-client</name>
+	<name>gp-java-client</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceClientImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceClientImpl.java
@@ -41,8 +41,8 @@ import java.util.TreeMap;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
+import com.google.common.io.BaseEncoding;
 import com.google.common.net.UrlEscapers;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -983,7 +983,7 @@ public class ServiceClientImpl extends ServiceClient {
         }
         String token = uid + ":" + secret;
         try {
-            return DatatypeConverter.printBase64Binary(token.getBytes("ISO-8859-1"));
+            return BaseEncoding.base64().encode(token.getBytes("ISO-8859-1"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -1030,7 +1030,7 @@ public class ServiceClientImpl extends ServiceClient {
 
             // signing
             byte[] hmac = mac.doFinal(msg);
-            credential.append(DatatypeConverter.printBase64Binary(hmac));
+            credential.append(BaseEncoding.base64().encode(hmac));
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
javax.xml.bind.DatatypeConverter may throw NullPointerException even for
static methods if JAXB context is not initialized. java.util.Base64 is
better, but it is new in Java 8. The SDK support Java 7, and we recently
added guava dependency, so we use the facility in guava library. This change fixes #13.

Also changed Eclipse project name from gaas-java-client to gp-java-client.