### PR TITLE
Changed a method name setNote to setNotes

### DIFF
--- a/src/main/java/com/ibm/g11n/pipeline/client/NewResourceEntryData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/NewResourceEntryData.java
@@ -86,7 +86,7 @@ public class NewResourceEntryData {
      * @param notes The notes for the new resource entry.
      * @return This object.
      */
-    public NewResourceEntryData setNote(List<String> notes) {
+    public NewResourceEntryData setNotes(List<String> notes) {
         this.notes = notes;
         return this;
     }

--- a/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientBundleTest.java
+++ b/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientBundleTest.java
@@ -830,7 +830,37 @@ public class ServiceClientBundleTest extends AbstractServiceClientTest {
     //
 
     @Test
-    public void uploadResourceEntries_NonExistinBundle_ShouldFail()
+    public void uploadResourceEntries_Notes_ShouldBeSaved()
+            throws ServiceException {
+        String bundleId = testBundleId("bundle1");
+        String source = "en";
+        createBundleWithLanguages(bundleId, source);
+        Map<String, NewResourceEntryData> resources = toNewResourceEntryMap(
+                TEST_RES1, true);
+        // Generate note (comment) for each entry by concatenating "Comment for
+        // " and
+        // key name.
+        String notePrefix = "Comment for ";
+        for (Entry<String, NewResourceEntryData> entry : resources.entrySet()) {
+            String note = notePrefix + entry.getKey();
+            entry.getValue().setNotes(Collections.singletonList(note));
+        }
+        client.uploadResourceEntries(bundleId, source, resources);
+
+        // Download entries
+        Map<String, ResourceEntryData> resultResources = client
+                .getResourceEntries(bundleId, source);
+
+        for (Entry<String, NewResourceEntryData> entry : resources.entrySet()) {
+            String key = entry.getKey();
+            ResourceEntryData resultData = resultResources.get(key);
+            assertNotNull("resource data for " + key, resultData);
+            assertEquals("notes should be saved", entry.getValue().getNotes(), resultData.getNotes());
+        }
+    }
+
+    @Test
+    public void uploadResourceEntries_NonExistingBundle_ShouldFail()
             throws ServiceException {
         String bundleId = testBundleId("bundle0");
         Map<String, NewResourceEntryData> resources = toNewResourceEntryMap(


### PR DESCRIPTION
com.ibm.g11n.pipeline.client.NewResourceEntryData has a method
setNote(List<String> notes). This was a mistake and should be
setNotes(...). The getter's name is getNotes().

This change fixes #20.

Also added a new test case including the method for improving method
test coverage.