### PR TITLE
Supports new translation request status CANCELLED

### DIFF
--- a/src/main/java/com/ibm/g11n/pipeline/client/NewTranslationRequestData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/NewTranslationRequestData.java
@@ -37,6 +37,7 @@ public class NewTranslationRequestData {
     private EnumSet<IndustryDomain> domains;
     private List<String> notes;
     private Map<String, String> metadata;
+    private Map<String, String> partnerParameters;
     private boolean submit;
 
     /**
@@ -231,6 +232,29 @@ public class NewTranslationRequestData {
      */
     public Map<String, String> getMetadata() {
         return metadata;
+    }
+
+    /**
+     * Sets a map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     * 
+     * @param partnerParameters A map containing key-value pairs specifying configuration parameters.
+     * @return This object.
+     */
+    public NewTranslationRequestData setPartnerParameters(Map<String, String> partnerParameters) {
+        this.partnerParameters = partnerParameters;
+        return this;
+    }
+
+    /**
+     * Returns a map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     * 
+     * @return A map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     */
+    public Map<String, String> getPartnerParameters() {
+        return partnerParameters;
     }
 
     /**

--- a/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestData.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestData.java
@@ -187,6 +187,19 @@ public abstract class TranslationRequestData {
     public abstract Map<String, String> getMetadata();
 
     /**
+     * Returns a map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     * 
+     * <p>Configuration parameters may vary depending on a service provider.
+     * This field should be empty unless a service provider asks a Globalization Pipeline
+     * user to provide some translation request specific information.
+     * 
+     * @return A map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     */
+    public abstract Map<String, String> getPartnerParameters();
+
+    /**
      * Returns the word count information of this translation request.
      * 
      * @return  The word count information of this translation request.

--- a/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestDataChangeSet.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestDataChangeSet.java
@@ -36,6 +36,7 @@ public class TranslationRequestDataChangeSet {
     private EnumSet<IndustryDomain> domains;
     private List<String> notes;
     private Map<String, String> metadata;
+    private Map<String, String> partnerParameters;
     private boolean submit;
 
     /**
@@ -218,6 +219,9 @@ public class TranslationRequestDataChangeSet {
      * Sets a map containing the metadata of this translation request represented
      * by key-value pairs.
      * 
+     * <p>This map should specify only delta from the current map. To remove a specific
+     * key from existing metadta filed, specify the key to be removed with an empty value.
+     * 
      * @param metadata  A map containing the metadata of this translation request represented
      * by key-value pairs.
      * @return  This object.
@@ -236,6 +240,33 @@ public class TranslationRequestDataChangeSet {
      */
     public Map<String, String> getMetadata() {
         return metadata;
+    }
+
+    /**
+     * Sets a map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     * 
+     * <p>This map should specify only delta from the current map. To remove a specific
+     * key from existing partnerParameters filed, specify the key to be removed with an
+     * empty value.
+     * 
+     * @param partnerParameters A map containing key-value pairs specifying configuration parameters.
+     * @return This object.
+     */
+    public TranslationRequestDataChangeSet setPartnerParameters(Map<String, String> partnerParameters) {
+        this.partnerParameters = partnerParameters;
+        return this;
+    }
+
+    /**
+     * Returns a map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     * 
+     * @return A map containing key-value pairs specifying configuration parameters
+     * passed to professional human post editing service provider.
+     */
+    public Map<String, String> getPartnerParameters() {
+        return partnerParameters;
     }
 
     /**

--- a/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestStatus.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestStatus.java
@@ -64,7 +64,8 @@ public enum TranslationRequestStatus {
     CANCELLED,
     /**
      * Unknown status. This is a special status only used when Globalization Pipeline
-     * service returns a status not supported by this SDK.
+     * service returns a status not supported by this SDK. This status should not be
+     * used for updating an existing translation request.
      */
     UNKNOWN;
 }

--- a/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestStatus.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/TranslationRequestStatus.java
@@ -24,31 +24,47 @@ public enum TranslationRequestStatus {
     /**
      * Draft status. The translation request is not yet submitted for
      * professional translation post editing service. Globalization Pipeline
-     * user can modify the contents of the translation request.
+     * user can edit the contents of the translation request or delete the
+     * request in this state.
      */
     DRAFT,
     /**
      * Submitted status. The translation request is submitted by user
-     * for professional translation post editing service. At this point,
-     * Globalization Pipeline user cannot modify the contents of the translation
-     * request.
+     * for professional translation post editing service. Globalization Pipeline
+     * user cannot modify the contents of the translation request in this state.
      */
     SUBMITTED,
     /**
      * Started status. The professional translation post editing service
      * provider acknowledged the translation request and started working on
-     * the request.
+     * the request. Globalization Pipeline user cannot modify the contents
+     * of the translation request in this state.
      */
     STARTED,
     /**
      * Translated status. The professional translation post editing service
-     * provider finished editing the translation.
+     * provider finished editing the translation. Globalization Pipeline user
+     * cannot modify the contents of the translation request in this state.
      */
     TRANSLATED,
     /**
      * Merged status. The final translation results from the professional translation
      * post editing provider were merged to the original Globalization Pipeline
-     * bundle.
+     * bundle. Globalization Pipeline user can modify only specific field(s) such
+     * as metadata field in this state.
      */
-    MERGED;
+    MERGED,
+    /**
+     * Cancelled status. The translation request is cancelled. Globalization Pipeline
+     * service or assigned professional translation post editing service provider may
+     * cancel a translation request when the service or the provider cannot handle
+     * the request for some reasons. Globalization Pipeline user cannot modify
+     * the contents of the translation request in this state, but can delete it.
+     */
+    CANCELLED,
+    /**
+     * Unknown status. This is a special status only used when Globalization Pipeline
+     * service returns a status not supported by this SDK.
+     */
+    UNKNOWN;
 }

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/TranslationRequestDataImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/TranslationRequestDataImpl.java
@@ -113,6 +113,15 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
     }
 
     @Override
+    public Map<String, String> getPartnerParameters() {
+        Map<String, String> partnerParameters = translationRequest.getPartnerParameters();
+        if (partnerParameters == null) {
+            return null;
+        }
+        return Collections.unmodifiableMap(partnerParameters);
+    }
+
+    @Override
     public Map<String, WordCountData> getWordCountData() {
         Map<String, WordCountData> wcDataByBundle = new TreeMap<>();
         Map<String, RestWordCountData> restWcDataByBundle = translationRequest.getWordCountsByBundle();
@@ -191,6 +200,7 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
         private Set<String> domains;
         private List<String> notes;
         private Map<String, String> metadata;
+        private Map<String, String> partnerParameters;
         private String status;
         private Map<String, RestWordCountData> wordCountsByBundle;
         private Date estimatedCompletion;
@@ -234,6 +244,10 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
 
         public Map<String, String> getMetadata() {
             return metadata;
+        }
+
+        public Map<String, String> getPartnerParameters() {
+            return partnerParameters;
         }
 
         public String getStatus() {
@@ -303,7 +317,8 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
         private Set<String> domains;
         private List<String> notes;
         private String status;
-//        private Map<String, String> metadata;
+        private Map<String, String> metadata;
+        private Map<String, String> partnerParameters;
 
         public RestInputTranslationRequestData(NewTranslationRequestData newTrData) {
             this.targetLanguagesByBundle = newTrData.getTargetLanguagesByBundle();
@@ -313,6 +328,8 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
             this.emails = newTrData.getEmails();
             this.phones = newTrData.getPhones();
             this.notes = newTrData.getNotes();
+            this.metadata = newTrData.getMetadata();
+            this.partnerParameters = newTrData.getPartnerParameters();
 
             this.status = newTrData.isSubmit() ? "SUBMITTED" : "DRAFT";
 
@@ -334,6 +351,8 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
             this.emails = trChangeSet.getEmails();
             this.phones = trChangeSet.getPhones();
             this.notes = trChangeSet.getNotes();
+            this.metadata = trChangeSet.getMetadata();
+            this.partnerParameters = trChangeSet.getPartnerParameters();
 
             this.status = trChangeSet.isSubmit() ? "SUBMITTED" : "DRAFT";
 
@@ -379,13 +398,16 @@ public class TranslationRequestDataImpl extends TranslationRequestData {
             return notes;
         }
 
-//        public Map<String, String> getMetadata() {
-//            return metadata;
-//        }
+        public Map<String, String> getMetadata() {
+            return metadata;
+        }
+
+        public Map<String, String> getPartnerParameters() {
+            return partnerParameters;
+        }
 
         public String getStatus() {
             return status;
         }
     }
-
 }

--- a/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientTRTest.java
+++ b/src/test/java/com/ibm/g11n/pipeline/client/ServiceClientTRTest.java
@@ -66,10 +66,25 @@ public class ServiceClientTRTest extends AbstractServiceClientBundleTest {
         final String trPartner = "IBM";
         final int wcByLang = 3;
  
+        final String trMetaKey1 = "mdk1";
+        final String trMetaVal1 = "mdv1";
+        final String trMetaKey2 = "mdk2";
+        final String trMetaVal2 = "mdv2";
+        final Map<String, String> trMetadata = new HashMap<>();
+        trMetadata.put(trMetaKey1, trMetaVal1);
+        trMetadata.put(trMetaKey2, trMetaVal2);
+
+        final String trPartnerParamKey1 = "ppk1";
+        final String trPartnerParamVal1 = "ppv1";
+        final Map<String, String> trPartnerParameters = new HashMap<>();
+        trPartnerParameters.put(trPartnerParamKey1, trPartnerParamVal1);
+
         newTrData
             .setName(trName)
             .setOrganization(trOrg)
-            .setEmails(trEmails);
+            .setEmails(trEmails)
+            .setMetadata(trMetadata)
+            .setPartnerParameters(trPartnerParameters);
 
         TranslationRequestData trData = client.createTranslationRequest(newTrData);
         assertNotNull("New TR", trData);
@@ -81,6 +96,8 @@ public class ServiceClientTRTest extends AbstractServiceClientBundleTest {
         assertEquals("New TR - emails", trEmails, trData.getEmails());
         assertEquals("New TR - partner", trPartner, trData.getPartner());   // implicitly set
         assertEquals("New TR - status", TranslationRequestStatus.DRAFT, trData.getStatus());
+        assertEquals("New TR - metadata", trMetadata, trData.getMetadata());
+        assertEquals("New TR - partnerParameters", trPartnerParameters, trData.getPartnerParameters());
 
         Map<String, WordCountData> wcByBundle = trData.getWordCountData();
         assertNotNull("New TR - words by bundle", wcByBundle);
@@ -106,6 +123,28 @@ public class ServiceClientTRTest extends AbstractServiceClientBundleTest {
         final List<String> trNotes = Collections.singletonList("This is a test bundle.");
         final EnumSet<IndustryDomain> trDomains = EnumSet.of(IndustryDomain.INFTECH, IndustryDomain.EDUCATN);
 
+        final String trMetaVal1Mod = "mdv1-mod";
+        final String trMetaKey3 = "mdk3";
+        final String trMetaVal3 = "mdv3";
+        final Map<String, String> trMetadataDelta = new HashMap<>();
+        trMetadataDelta.put(trMetaKey1, trMetaVal1Mod);
+        trMetadataDelta.put(trMetaKey3, trMetaVal3);
+
+        final Map<String, String> trMetadataExpected = new HashMap<>();
+        trMetadataExpected.put(trMetaKey1, trMetaVal1Mod);
+        trMetadataExpected.put(trMetaKey2, trMetaVal2);
+        trMetadataExpected.put(trMetaKey3, trMetaVal3);
+
+
+        final String trPartnerParamKey2 = "ppk2";
+        final String trPartnerParamVal2 = "ppv2";
+        final Map<String, String> trPartnerParametersDelta = new HashMap<>();
+        trPartnerParametersDelta.put(trPartnerParamKey1, "");    // delete "ppk1"
+        trPartnerParametersDelta.put(trPartnerParamKey2, trPartnerParamVal2);
+
+        final Map<String, String> trPartnerParametersExpected = new HashMap<>();
+        trPartnerParametersExpected.put(trPartnerParamKey2, trPartnerParamVal2);
+
         final String addTrgLang = "de";
         Map<String, Set<String>> updTrgLangsByBundle = new HashMap<>();
         Set<String> updTrgLangs = new HashSet<>();
@@ -118,6 +157,8 @@ public class ServiceClientTRTest extends AbstractServiceClientBundleTest {
             .setNotes(trNotes)
             .setDomains(trDomains)
             .setTargetLanguagesByBundle(updTrgLangsByBundle)
+            .setMetadata(trMetadataDelta)
+            .setPartnerParameters(trPartnerParametersDelta)
             .setSubmit(false);
 
         TranslationRequestData trDataU = client.updateTranslationRequest(trId, trChanges);
@@ -125,6 +166,8 @@ public class ServiceClientTRTest extends AbstractServiceClientBundleTest {
         assertEquals("TR(upd):" + trId + " - name", updTrName, trDataU.getName());
         assertEquals("TR(upd):" + trId + " - notes", trNotes, trDataU.getNotes());
         assertEquals("TR(upd):" + trId + " - domains", trDomains, trDataU.getDomains());
+        assertEquals("TR(upd):" + trId + " - metadata", trMetadataExpected, trDataU.getMetadata());
+        assertEquals("TR(upd):" + trId + " - partnerParameters", trPartnerParametersExpected, trDataU.getPartnerParameters());
 
         // Unchanged
         assertEquals("TR(upd):" + trId + " - organization", trOrg, trDataU.getOrganization());

--- a/src/test/java/com/ibm/g11n/pipeline/client/impl/EnumWithFallbackAdapterTest.java
+++ b/src/test/java/com/ibm/g11n/pipeline/client/impl/EnumWithFallbackAdapterTest.java
@@ -1,0 +1,87 @@
+/*  
+ * Copyright IBM Corp. 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.g11n.pipeline.client.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+import org.junit.Test;
+
+import com.ibm.g11n.pipeline.client.TranslationRequestStatus;
+import com.ibm.g11n.pipeline.client.TranslationStatus;
+import com.ibm.g11n.pipeline.client.impl.ServiceClientImpl.EnumWithFallbackAdapter;
+
+/**
+ * @author yoshito_umaoka
+ *
+ */
+public class EnumWithFallbackAdapterTest {
+    @Test
+    public void testTranslationStatus() {
+        final EnumWithFallbackAdapter<TranslationStatus> adapter =
+                new EnumWithFallbackAdapter<>(TranslationStatus.UNKNOWN);
+
+        final LinkedHashMap<String, TranslationStatus> testcaseMap = new LinkedHashMap<>();
+        testcaseMap.put("SOURCE_LANGUAGE", TranslationStatus.SOURCE_LANGUAGE);
+        testcaseMap.put("IN_PROGRESS", TranslationStatus.IN_PROGRESS);
+        testcaseMap.put("TRANSLATED", TranslationStatus.TRANSLATED);
+        testcaseMap.put("UNCONFIGURED", TranslationStatus.UNCONFIGURED);
+        testcaseMap.put("FAILED", TranslationStatus.FAILED);
+        testcaseMap.put("UNKNOWN", TranslationStatus.UNKNOWN);
+
+        testcaseMap.put("In_Progress", TranslationStatus.IN_PROGRESS);
+        testcaseMap.put("translated", TranslationStatus.TRANSLATED);
+
+        // fallback
+        testcaseMap.put("UNCONFIGURED status", TranslationStatus.UNKNOWN);
+        testcaseMap.put("In Progress", TranslationStatus.UNKNOWN);
+        testcaseMap.put("UNKNOWN_REALLY", TranslationStatus.UNKNOWN);
+        testcaseMap.put("", TranslationStatus.UNKNOWN);
+
+        for (Entry<String, TranslationStatus> testcase : testcaseMap.entrySet()) {
+            assertEquals(testcase.getValue(), adapter.toEnumWithFallback(testcase.getKey()));
+        }
+    }
+
+    @Test
+    public void testTranslationRequestStatus() {
+        final EnumWithFallbackAdapter<TranslationRequestStatus> adapter =
+                new EnumWithFallbackAdapter<>(TranslationRequestStatus.UNKNOWN);
+
+        final LinkedHashMap<String, TranslationRequestStatus> testcaseMap = new LinkedHashMap<>();
+        testcaseMap.put("DRAFT", TranslationRequestStatus.DRAFT);
+        testcaseMap.put("SUBMITTED", TranslationRequestStatus.SUBMITTED);
+        testcaseMap.put("STARTED", TranslationRequestStatus.STARTED);
+        testcaseMap.put("TRANSLATED", TranslationRequestStatus.TRANSLATED);
+        testcaseMap.put("MERGED", TranslationRequestStatus.MERGED);
+        testcaseMap.put("CANCELLED", TranslationRequestStatus.CANCELLED);
+        testcaseMap.put("UNKNOWN", TranslationRequestStatus.UNKNOWN);
+
+        testcaseMap.put("Draft", TranslationRequestStatus.DRAFT);
+        testcaseMap.put("submitted", TranslationRequestStatus.SUBMITTED);
+
+        // fallback
+        testcaseMap.put("DRAFT created", TranslationRequestStatus.UNKNOWN);
+        testcaseMap.put("UNKNOWN_REALLY", TranslationRequestStatus.UNKNOWN);
+        testcaseMap.put("", TranslationRequestStatus.UNKNOWN);
+
+        for (Entry<String, TranslationRequestStatus> testcase : testcaseMap.entrySet()) {
+            assertEquals(testcase.getValue(), adapter.toEnumWithFallback(testcase.getKey()));
+        }
+    }
+}


### PR DESCRIPTION
- New translation request status enum - CANCELLED
- Generic enum deserialization fallback, including
TranslationRequestStatus.
- New field - partnerParameters
- Refined some Javadoc API comments
- Test case of these changes